### PR TITLE
domain format no longer works with regex

### DIFF
--- a/block.aspx
+++ b/block.aspx
@@ -17,9 +17,7 @@
         if (Request.QueryString["url"] != null)
         {
             // Since the decisions are made only on the domain, let's *just* show the domain.
-            // Hiding REGEX since the syntax returned no longer is parsed correctly by the regex and returns empty
-            //Match m = Regex.Match(Rot13.Transform(Request.QueryString["url"]), "[a-z]+://([^/]+)/", RegexOptions.IgnoreCase);
-            //DomainLabel.Text = m.Groups[1].ToString();
+
             DomainLabel.Text = Rot13.Transform(Request.QueryString["url"]);
         }
         else

--- a/block.aspx
+++ b/block.aspx
@@ -17,8 +17,10 @@
         if (Request.QueryString["url"] != null)
         {
             // Since the decisions are made only on the domain, let's *just* show the domain.
-            Match m = Regex.Match(Rot13.Transform(Request.QueryString["url"]), "[a-z]+://([^/]+)/", RegexOptions.IgnoreCase);
-            DomainLabel.Text = m.Groups[1].ToString();
+            // Hiding REGEX since the syntax returned no longer is parsed correctly by the regex and returns empty
+            //Match m = Regex.Match(Rot13.Transform(Request.QueryString["url"]), "[a-z]+://([^/]+)/", RegexOptions.IgnoreCase);
+            //DomainLabel.Text = m.Groups[1].ToString();
+            DomainLabel.Text = Rot13.Transform(Request.QueryString["url"]);
         }
         else
         {


### PR DESCRIPTION
removing the regex to the ROT13 transform to allow block page to show
the domain input. Goal is to prevent cases where the domain pass through is blank on our sample page
