### PR TITLE
Patch to work again

### DIFF
--- a/block.aspx
+++ b/block.aspx
@@ -16,9 +16,10 @@
         // Get the domain query parameter, use example.com if we don't have one.
         if (Request.QueryString["url"] != null)
         {
-            // Since the decisions are made only on the domain, let's *just* show the domain.
-            Match m = Regex.Match(Rot13.Transform(Request.QueryString["url"]), "[a-z]+://([^/]+)/", RegexOptions.IgnoreCase);
-            DomainLabel.Text = m.Groups[1].ToString();
+            // Since only the domain (no http) is returned from the landers, this is the domain label to print
+             DomainLabel.Text = Rot13.Transform(Request.QueryString["url"]);
+             
+
         }
         else
         {

--- a/block.html
+++ b/block.html
@@ -12,25 +12,42 @@
 // be URL encoded.  unescape lends consistent results for the purposes of this exercise
 
 /* Rot13 implementation to decode domain data */
-function rot13(str) {
-    var decoded = '';
-    for (n in str) {
-        var char = str[n]
-        if (!/[A-Z]/i.match(char)) {
-            decoded += char
-        }
-        else {
-            var charCode = str.charCodeAt(n)
-            if (charCode < 97) {
-                charChode = (charCode - 52) % 26 + 65
-            }
-            else {
-                charCode = (charCode - 84) % 26 + 97
-            }
-            decoded += String.fromCharCode(charCode)
-        }
+
+/*
+  rot13.js
+  ROT13 + ROT5 Encoder/Decoder
+  http://rot47.net
+http://rot47.net/rot13.html
+*/
+function rot13(str) 
+{
+  return str.replace(/[a-zA-Z]/g, function(c){
+    return String.fromCharCode((c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26);
+  });
+}
+function rot5(str) 
+{
+  var s = [];
+  for (i = 0; i < str.length; i ++)
+  {
+    idx = str.charCodeAt(i);
+    if ((idx >= 48) && (idx <= 57))
+    {
+      if (idx <= 52)
+      {
+        s[i] = String.fromCharCode(((idx + 5)));
+      }
+      else
+      {
+        s[i] = String.fromCharCode(((idx - 5)));
+      }
+    } 
+    else
+    {
+      s[i] = String.fromCharCode(idx);
     }
-    return decoded
+  }
+  return s.join('');
 }
 
 $(function() {
@@ -39,8 +56,7 @@ $(function() {
     if (domain) {
         domain = rot13(unescape(domain));
 
-        // Since the decisions are made only on the domain, let's *just* show the domain.
-        domain = /[a-z]+:\/\/([^\/]+)\//i.exec(domain)[1];
+        // Since http:// is no longer passed, the above is the domain to print
     }
     else {
         domain = "www.example.com";

--- a/block.php
+++ b/block.php
@@ -3,9 +3,9 @@
 if (!isset($_REQUEST['url']))
     $domain = 'www.example.com';
 else {
-    // Since the decisions are made only on the domain, let's *just* show the domain.
-    preg_match('#[a-z]+://([^/]+)/#i', str_rot13($_REQUEST['url']), $domain);
-    $domain = $domain[1];
+    // Since the decisions are made only on the domain, and http:// is no longer passed in the request, the domain is the url query.
+    $domain = str_rot13($_REQUEST['url']);
+    
 }
 
 // Set a default type to "block".  This allows us to just referance the block page


### PR DESCRIPTION
All: remove regex since http:// is no longer passed by the block page
html: patched rot13 implementation to work again:
(!/[A-Z]/i.match(char)) was flagging an error
